### PR TITLE
Add support for multi-platform images (amd64 and arm64)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,17 +53,22 @@ jobs:
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      # Set up emulation for multi-platform builds
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       # Set up the builder
-      # This will allow for more complex setups (different platforms, export cache, ...)
-      # Not necessary right now, but better for the future.
+      # This allows for more complex setups (different platforms, export cache, ...)
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64, linux/arm64
 
       # Build the image, and push (on non-PRs)
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,13 @@ ENV POSTGRES_HOST_AUTH_METHOD='trust'
 # Installing through pip (rather than apt) is easier for multi-platform...
 # Note: The `setup.py` script requires `pkg_resources`, but it is uninstalled
 #   when uninstalling python3-pip. So we explicitly install it through apt.
-# TODO: get the path to `pgadmin4` automatically rather than assuming!
+# We also get the path to the pgadmin4 package automatically; it should yield
+#   something like `/usr/local/lib/python3.11/dist-packages/pgadmin4`.
+
 RUN set -ex; \
     apt-get update -y && apt-get install -y python3 python3-pip python3-pkg-resources; \
     /usr/bin/pip3 install --break-system-packages pgadmin4; \
-    mkdir /usr/pgadmin4 && ln -s /usr/local/lib/python3.11/dist-packages/pgadmin4 /usr/pgadmin4/web; \
+    mkdir /usr/pgadmin4 && ln -s $(/usr/bin/python3 -c 'import pgadmin4; print(pgadmin4.__path__[0]);') /usr/pgadmin4/web; \
     apt-get remove --purge -y python3-pip; \
     apt-get autoclean -y && apt-get autoremove -y; \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM postgres:17.2-bookworm
 # Set a few metadata (labels)
 LABEL org.opencontainers.image.authors="Remy Chaput" \
       org.opencontainers.image.url="https://github.com/rchaput/postgres-pgadmin-docker" \
-      org.opencontainers.image.version="1.0" \
+      org.opencontainers.image.version="2.0" \
       org.opencontainers.image.name="Postgres pgAdmin4" \
       org.opencontainers.image.description="A Docker image that contains both PostgreSQL (a database management system) and pgAdmin4 (a Web UI for Postgres), for teaching purposes."
 
@@ -22,9 +22,8 @@ ENV POSTGRES_HOST_AUTH_METHOD='trust'
 # Installing through pip (rather than apt) is easier for multi-platform...
 # Note: The `setup.py` script requires `pkg_resources`, but it is uninstalled
 #   when uninstalling python3-pip. So we explicitly install it through apt.
-# We also get the path to the pgadmin4 package automatically; it should yield
+# We get the path to the pgadmin4 package automatically; it should yield
 #   something like `/usr/local/lib/python3.11/dist-packages/pgadmin4`.
-
 RUN set -ex; \
     apt-get update -y && apt-get install -y python3 python3-pip python3-pkg-resources; \
     /usr/bin/pip3 install --break-system-packages pgadmin4; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,15 @@ ENV POSTGRES_HOST_AUTH_METHOD='trust'
 # See https://www.pgadmin.org/download/pgadmin-4-apt/
 # And https://hub.docker.com/r/dcagatay/pwless-pgadmin4 for passwordless
 # Installing through pip (rather than apt) is easier for multi-platform...
+# Note: The `setup.py` script requires `pkg_resources`, but it is uninstalled
+#   when uninstalling python3-pip. So we explicitly install it through apt.
 # TODO: get the path to `pgadmin4` automatically rather than assuming!
 RUN set -ex; \
-    apt-get update -y && apt-get install -y python3 python3-pip; \
+    apt-get update -y && apt-get install -y python3 python3-pip python3-pkg-resources; \
     /usr/bin/pip3 install --break-system-packages pgadmin4; \
     mkdir /usr/pgadmin4 && ln -s /usr/local/lib/python3.11/dist-packages/pgadmin4 /usr/pgadmin4/web; \
+    apt-get remove --purge -y python3-pip; \
+    apt-get autoclean -y && apt-get autoremove -y; \
     rm -rf /var/lib/apt/lists/*
 
 

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ BRANCH_NAME = $(shell git branch --show-current | sed -e 's/\//-/g')
 SHORT_SHA = $(shell git rev-parse --short HEAD)
 
 build-docker: $(DOCKER_SRC)
-	docker build --platform linux/amd64 --tag $(IMAGE_NAME):$(BRANCH_NAME) --tag $(IMAGE_NAME):$(BRANCH_NAME)_$(SHORT_SHA) .
+	docker build --tag $(IMAGE_NAME):$(BRANCH_NAME) --tag $(IMAGE_NAME):$(BRANCH_NAME)_$(SHORT_SHA) .
 
 run-docker:
-	docker run --platform linux/amd64 --name $(CONTAINER_NAME) -p 127.0.0.1:5432:5432 -p 127.0.0.1:5050:5050 -d $(IMAGE_NAME):$(BRANCH_NAME)
+	docker run --name $(CONTAINER_NAME) -p 127.0.0.1:5432:5432 -p 127.0.0.1:5050:5050 -d $(IMAGE_NAME):$(BRANCH_NAME)
 
 populate-docker:
 	docker exec -it $(CONTAINER_NAME) /usr/bin/pg_restore -d dvdrental --create --username=postgres /root/dvdrental.tar

--- a/Readme.md
+++ b/Readme.md
@@ -33,14 +33,12 @@ docker pull rchaput/postgres_pgadmin4:latest
 Then instantiate a new container with:
 
 ```shell
-docker run --platform linux/amd64 --name YOUR_CONTAINER_NAME -p 127.0.0.1:5050:5050 -d rchaput/postgres_pgadmin4:latest
+docker run --name YOUR_CONTAINER_NAME -p 127.0.0.1:5050:5050 -d rchaput/postgres_pgadmin4:latest
 ```
 
 You may now access the pgAdmin4 UI at [http://localhost:5050/](http://localhost:5050/)
 
 *Notes*:
-
-- pgAdmin4 was only tested with the linux/amd64 platform. As such, this image is (for now) only available for this platform. You may omit the `--platform linux/amd64` argument if this is already the platform you are using, but you **must** include it with any other platform, including, e.g., Windows, or Apple Silicon. The image should work through the emulation layer.
 
 - Specifying `127.0.0.1` when binding the port ensures that only the local interface can be used to access pgAdmin4. Using the (concise) `5050:5050` notation binds to *all* interfaces and is therefore **unsafe**.
 
@@ -81,7 +79,7 @@ You may also restore a database from such a backup file directly from the comman
 
 ---
 
-The base Postgres image also exposes the `5432` port for direct access to Postgres. This should not be necessary, as you can access Postgres through pgAdmin4, but you may also bind this port when instantiating the container, by using several `-p` arguments: `docker run --platform linux/amd64 --name YOUR_CONTAINER_NAME -p 127.0.0.1:5432:5432 -p 127.0.0.1:5050:5050 -d rchaput/postgres_pgadmin4:latest`
+The base Postgres image also exposes the `5432` port for direct access to Postgres. This should not be necessary, as you can access Postgres through pgAdmin4, but you may also bind this port when instantiating the container, by using several `-p` arguments: `docker run --name YOUR_CONTAINER_NAME -p 127.0.0.1:5432:5432 -p 127.0.0.1:5050:5050 -d rchaput/postgres_pgadmin4:latest`
 
 Of course, the host port can be changed if 5432 or 5050 are already in use.
 

--- a/pgadmin_config.py
+++ b/pgadmin_config.py
@@ -2,6 +2,27 @@
 SERVER_MODE = False
 MASTER_PASSWORD_REQUIRED = False
 
+# Allow connections from outside the container
+DEFAULT_SERVER = '0.0.0.0'
+
+# The `config_distro.py` when installing through Pip does not contain these
+# paths. We must specify them so pgAdmin4 can backup, restore, ...
+# (any external process that require invoking `/usr/bin/pg_*`)
+DEFAULT_BINARY_PATHS = {
+    "pg": "/usr/bin",
+    "pg-13": "",
+    "pg-14": "",
+    "pg-15": "",
+    "pg-16": "",
+    "pg-17": "",
+    "ppas": "/usr/bin",
+    "ppas-13": "",
+    "ppas-14": "",
+    "ppas-15": "",
+    "ppas-16": "",
+    "ppas-17": ""
+}
+
 # Change some paths for data and logs
 # (because we have forced desktop-mode)
 DATA_DIR = '/var/lib/pgadmin4'

--- a/run_pgadmin.sh
+++ b/run_pgadmin.sh
@@ -1,15 +1,3 @@
 #!/bin/sh
 
-uwsgi \
-    --http-socket 0.0.0.0:5050 \
-    --processes 1 \
-    --threads 25 \
-    --chdir /usr/pgadmin4/web/ \
-    --mount /=pgAdmin4:app \
-    --plugin python3 \
-    -H /usr/pgadmin4/venv/ \
-    --wsgi-file /usr/pgadmin4/web/pgAdmin4.wsgi \
-    --manage-script-name \
-    --py-sys-executable /usr/pgadmin4/venv/bin/python
-    # --uid pgadmin \
-    # --gid pgadmin
+/usr/bin/python3 /usr/pgadmin4/web/pgAdmin4.py


### PR DESCRIPTION
We initially supported only linux/amd64, i.e., the x86-64 processors on Linux. This is the most used platform, and should cover most users. However, some users, especially on recent Apple Silicon hardware, use instead linux/arm64.
This PR adds support for multi-platform builds, i.e., images that run on both linux/amd64 and linux/arm64 platforms.

Because pgAdmin4 does not provide packages that officially support arm64, we had to change the way we provide it:
- it is now installed as a Python package, through pip (rather than a Debian package, through apt-get);
- for some reason, it cannot be loaded through uwsgi, and is now served through its integrated Flask web server.